### PR TITLE
fix: use parseInt to prevent flicker of abstract shape

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,7 +28,7 @@
 
 <div class="abstract">
     <svg viewBox="0 0 500 150" preserveAspectRatio="none">
-        <path d={`M0.00,${scrollYBind * 2}.98 C216.98,80.06 349.20,-49.98 500.00,89.98 L500.00,180.00 L0.00,150.00 Z`}
+        <path d={`M0.00,${parseInt(scrollYBind) * 2}.98 C216.98,80.06 349.20,-49.98 500.00,89.98 L500.00,180.00 L0.00,150.00 Z`}
               style="stroke: none; fill: #ecb9ff;">
         </path>
     </svg>


### PR DESCRIPTION
The abstract would flicker when passed an invalid value.This seemed to be most prevalent when using a screen zoom of 150% or 175%.  Using parseInt should fix it.

Error in console:
```
Error: <path> attribute d: Expected number, "…571533203125.98 C216.98,80.06 34…".
```

Video example:
https://github.com/cursusdb/cursusdb-web/assets/1195435/671a9833-b0c1-4246-8b23-fb890cfa2e93

